### PR TITLE
Replace cursor trail with blue glowy orb cursor

### DIFF
--- a/client/components/ui/theme-toggle.tsx
+++ b/client/components/ui/theme-toggle.tsx
@@ -10,7 +10,7 @@ export function ThemeToggle() {
       variant="ghost"
       size="icon"
       onClick={toggleTheme}
-      className="fixed top-6 right-6 z-50 h-10 w-10 rounded-full bg-white/10 backdrop-blur-md border border-white/20 hover:bg-white/20 transition-all duration-300 hover:scale-110"
+      className="fixed top-6 right-6 z-50 h-10 w-10 rounded-full bg-white/10 backdrop-blur-md border border-white/20 hover:bg-white/20 transition-all duration-300 hover:scale-110 cursor-none"
       style={{
         background:
           theme === "light" ? "rgba(0, 0, 0, 0.1)" : "rgba(255, 255, 255, 0.1)",

--- a/client/global.css
+++ b/client/global.css
@@ -375,6 +375,26 @@
   }
 }
 
+@keyframes orb-pulse {
+  0%,
+  100% {
+    transform: translate(-50%, -50%) scale(1);
+    filter: brightness(1) saturate(1);
+  }
+  25% {
+    transform: translate(-50%, -50%) scale(1.05);
+    filter: brightness(1.1) saturate(1.2);
+  }
+  50% {
+    transform: translate(-50%, -50%) scale(1.1);
+    filter: brightness(1.2) saturate(1.4);
+  }
+  75% {
+    transform: translate(-50%, -50%) scale(1.05);
+    filter: brightness(1.1) saturate(1.2);
+  }
+}
+
 @keyframes button-drift {
   0%,
   100% {

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -190,7 +190,7 @@ export default function Index() {
       <div className="fixed inset-0 pointer-events-none z-50">
         {cursorTrails.map((trail, index) => (
           <div
-            key={trail.id}
+            key={`${trail.id}-${index}`}
             className="absolute w-3 h-3 rounded-full"
             style={{
               left: trail.x - 6,

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -190,7 +190,7 @@ export default function Index() {
         <ThemeToggle />
       </div>
 
-      {/* Custom Blue Glowy Orb Cursor - Diffuse Style */}
+      {/* Custom Blue Glowy Orb Cursor - Figma Design Match */}
       <div
         className={`fixed pointer-events-none z-[60] transition-opacity duration-300 ${
           customCursor.visible ? 'opacity-100' : 'opacity-0'
@@ -201,60 +201,25 @@ export default function Index() {
           transform: 'translate(-50%, -50%)',
         }}
       >
-        {/* Diffuse cursor orb with multiple glow layers */}
-        <div className="relative">
-          {/* Outermost diffuse glow */}
-          <div
-            className="absolute rounded-full"
-            style={{
-              width: '80px',
-              height: '80px',
-              background: 'radial-gradient(circle, rgba(73, 146, 255, 0.15) 0%, rgba(73, 146, 255, 0.08) 30%, rgba(73, 146, 255, 0.03) 60%, transparent 100%)',
-              transform: 'translate(-50%, -50%)',
-              filter: 'blur(4px)',
-              animation: 'gentle-pulse 3s ease-in-out infinite',
-            }}
-          />
-          {/* Secondary glow layer */}
-          <div
-            className="absolute rounded-full"
-            style={{
-              width: '50px',
-              height: '50px',
-              background: 'radial-gradient(circle, rgba(73, 146, 255, 0.25) 0%, rgba(73, 146, 255, 0.15) 40%, rgba(73, 146, 255, 0.05) 70%, transparent 100%)',
-              transform: 'translate(-50%, -50%)',
-              filter: 'blur(2px)',
-              animation: 'gentle-pulse 3s ease-in-out infinite 0.5s',
-            }}
-          />
-          {/* Main glow */}
-          <div
-            className="absolute rounded-full"
-            style={{
-              width: '30px',
-              height: '30px',
-              background: 'radial-gradient(circle, rgba(73, 146, 255, 0.4) 0%, rgba(73, 146, 255, 0.25) 50%, rgba(73, 146, 255, 0.1) 80%, transparent 100%)',
-              transform: 'translate(-50%, -50%)',
-              filter: 'blur(1px)',
-              animation: 'orb-pulse 3s ease-in-out infinite',
-            }}
-          />
-          {/* Core bright center */}
-          <div
-            className="absolute rounded-full"
-            style={{
-              width: '8px',
-              height: '8px',
-              background: 'radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.9) 0%, rgba(73, 146, 255, 0.8) 40%, rgba(57, 135, 227, 0.9) 100%)',
-              transform: 'translate(-50%, -50%)',
-              boxShadow: `
-                0 0 20px rgba(73, 146, 255, 0.6),
-                0 0 40px rgba(73, 146, 255, 0.4),
-                0 0 60px rgba(73, 146, 255, 0.2)
-              `,
-            }}
-          />
-        </div>
+        {/* Figma-matched cursor orb */}
+        <div
+          className="absolute rounded-full"
+          style={{
+            width: '18px',
+            height: '19px',
+            borderRadius: '19px',
+            background: 'linear-gradient(90deg, #3FBAFF 0.45%, #4992FF 60.5%, #3987E3 122.16%)',
+            boxShadow: `
+              0 0 31px 0 #4992FF,
+              0 0 18px 0 #4992FF,
+              0 0 10px 0 #4992FF,
+              0 0 5px 0 #4992FF,
+              0 0 1.5px 0 #4992FF
+            `,
+            filter: 'blur(1.1px)',
+            transform: 'translate(-50%, -50%)',
+          }}
+        />
       </div>
 
       {/* Enhanced Background Elements */}

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -13,9 +13,7 @@ export default function Index() {
   });
   const badgeRef = useRef<HTMLDivElement>(null);
   const [isLoaded, setIsLoaded] = useState(false);
-  const [cursorTrails, setCursorTrails] = useState<
-    Array<{ id: number; x: number; y: number }>
-  >([]);
+  const [customCursor, setCustomCursor] = useState({ x: 0, y: 0, visible: false });
 
   // Framer Motion animation variants
   const containerVariants = {
@@ -109,33 +107,36 @@ export default function Index() {
         y: e.clientY / window.innerHeight,
       });
 
-      // Add cursor trail effect
-      setCursorTrails((prev) => {
-        const newTrail = {
-          id: Date.now(),
-          x: e.clientX,
-          y: e.clientY,
-        };
-        return [...prev.slice(-8), newTrail]; // Keep only last 8 trails
+      // Update custom cursor position
+      setCustomCursor({
+        x: e.clientX,
+        y: e.clientY,
+        visible: true,
       });
     };
 
+    const handleMouseEnter = () => {
+      setCustomCursor(prev => ({ ...prev, visible: true }));
+    };
+
+    const handleMouseLeave = () => {
+      setCustomCursor(prev => ({ ...prev, visible: false }));
+    };
+
     window.addEventListener("mousemove", handleMouseMove);
+    window.addEventListener("mouseenter", handleMouseEnter);
+    window.addEventListener("mouseleave", handleMouseLeave);
 
     // Trigger loading animation after a short delay
     const loadTimer = setTimeout(() => {
       setIsLoaded(true);
     }, 300);
 
-    // Clean up old cursor trails
-    const trailCleanup = setInterval(() => {
-      setCursorTrails((prev) => prev.slice(-5));
-    }, 100);
-
     return () => {
       window.removeEventListener("mousemove", handleMouseMove);
+      window.removeEventListener("mouseenter", handleMouseEnter);
+      window.removeEventListener("mouseleave", handleMouseLeave);
       clearTimeout(loadTimer);
-      clearInterval(trailCleanup);
     };
   }, []);
 
@@ -175,7 +176,7 @@ export default function Index() {
 
   return (
     <motion.div
-      className={`relative min-h-screen overflow-hidden transition-all duration-500 ${
+      className={`relative min-h-screen overflow-hidden transition-all duration-500 cursor-none ${
         theme === "light"
           ? "bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-100"
           : "bg-black"
@@ -186,22 +187,70 @@ export default function Index() {
     >
       {/* Theme Toggle */}
       <ThemeToggle />
-      {/* Cursor Trail Effects */}
-      <div className="fixed inset-0 pointer-events-none z-50">
-        {cursorTrails.map((trail, index) => (
+
+      {/* Custom Blue Glowy Orb Cursor */}
+      <div
+        className={`fixed pointer-events-none z-[60] transition-opacity duration-300 ${
+          customCursor.visible ? 'opacity-100' : 'opacity-0'
+        }`}
+        style={{
+          left: customCursor.x,
+          top: customCursor.y,
+          transform: 'translate(-50%, -50%)',
+        }}
+      >
+        {/* Main cursor orb */}
+        <div className="relative">
+          {/* Outer glow rings */}
           <div
-            key={`${trail.id}-${index}`}
-            className="absolute w-3 h-3 rounded-full"
+            className="absolute rounded-full animate-pulse"
             style={{
-              left: trail.x - 6,
-              top: trail.y - 6,
-              background: `radial-gradient(circle, rgba(73, 146, 255, ${0.8 - index * 0.1}) 0%, transparent 70%)`,
-              animation: `cursor-trail 0.8s ease-out forwards`,
-              animationDelay: `${index * 0.05}s`,
-              transform: `scale(${1 - index * 0.1})`,
+              width: '32px',
+              height: '32px',
+              background: 'radial-gradient(circle, rgba(73, 146, 255, 0.3) 0%, rgba(73, 146, 255, 0.1) 50%, transparent 100%)',
+              transform: 'translate(-50%, -50%)',
+              animation: 'gentle-pulse 2s ease-in-out infinite',
             }}
           />
-        ))}
+          <div
+            className="absolute rounded-full animate-pulse"
+            style={{
+              width: '20px',
+              height: '20px',
+              background: 'radial-gradient(circle, rgba(73, 146, 255, 0.5) 0%, rgba(73, 146, 255, 0.2) 50%, transparent 100%)',
+              transform: 'translate(-50%, -50%)',
+              animation: 'gentle-pulse 2s ease-in-out infinite 0.3s',
+            }}
+          />
+          {/* Core orb */}
+          <div
+            className="absolute rounded-full"
+            style={{
+              width: '12px',
+              height: '12px',
+              background: 'radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.9) 0%, rgba(73, 146, 255, 0.9) 30%, rgba(57, 135, 227, 1) 100%)',
+              transform: 'translate(-50%, -50%)',
+              boxShadow: `
+                0 0 15px rgba(73, 146, 255, 0.8),
+                0 0 25px rgba(73, 146, 255, 0.6),
+                0 0 35px rgba(73, 146, 255, 0.4),
+                inset 0 1px 2px rgba(255, 255, 255, 0.3)
+              `,
+              animation: 'orb-pulse 3s ease-in-out infinite',
+            }}
+          />
+          {/* Inner highlight */}
+          <div
+            className="absolute rounded-full"
+            style={{
+              width: '4px',
+              height: '4px',
+              background: 'rgba(255, 255, 255, 0.9)',
+              transform: 'translate(-30%, -30%)',
+              filter: 'blur(0.5px)',
+            }}
+          />
+        </div>
       </div>
 
       {/* Enhanced Background Elements */}

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -397,7 +397,7 @@ export default function Index() {
       >
         <div
           ref={badgeRef}
-          className="inline-flex items-center gap-2 px-3 py-2 md:py-3 rounded-full backdrop-blur-xs hover:bg-white/15 transition-all duration-500 hover:scale-105 relative overflow-hidden"
+          className="inline-flex items-center gap-2 px-3 py-2 md:py-3 rounded-full backdrop-blur-xs hover:bg-white/15 transition-all duration-500 hover:scale-105 relative overflow-hidden cursor-none"
           style={{
             background: "rgba(255, 255, 255, 0.1)",
             border: "2px solid transparent",

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -14,6 +14,7 @@ export default function Index() {
   const badgeRef = useRef<HTMLDivElement>(null);
   const [isLoaded, setIsLoaded] = useState(false);
   const [customCursor, setCustomCursor] = useState({ x: 0, y: 0, visible: false });
+  const cursorRef = useRef<HTMLDivElement>(null);
 
   // Framer Motion animation variants
   const containerVariants = {
@@ -107,12 +108,14 @@ export default function Index() {
         y: e.clientY / window.innerHeight,
       });
 
-      // Update custom cursor position
-      setCustomCursor({
-        x: e.clientX,
-        y: e.clientY,
-        visible: true,
-      });
+      // Update custom cursor position with direct transform for better performance
+      if (cursorRef.current) {
+        cursorRef.current.style.transform = `translate3d(${e.clientX}px, ${e.clientY}px, 0)`;
+      }
+
+      if (!customCursor.visible) {
+        setCustomCursor(prev => ({ ...prev, visible: true }));
+      }
     };
 
     const handleMouseEnter = () => {
@@ -190,15 +193,17 @@ export default function Index() {
         <ThemeToggle />
       </div>
 
-      {/* Custom Blue Glowy Orb Cursor - Figma Design Match */}
+      {/* Custom Blue Glowy Orb Cursor - Optimized for Performance */}
       <div
+        ref={cursorRef}
         className={`fixed pointer-events-none z-[60] transition-opacity duration-300 ${
           customCursor.visible ? 'opacity-100' : 'opacity-0'
         }`}
         style={{
-          left: customCursor.x,
-          top: customCursor.y,
-          transform: 'translate(-50%, -50%)',
+          left: 0,
+          top: 0,
+          transform: 'translate3d(0px, 0px, 0)',
+          willChange: 'transform',
         }}
       >
         {/* Figma-matched cursor orb */}

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -186,9 +186,11 @@ export default function Index() {
       animate={isLoaded ? "visible" : "hidden"}
     >
       {/* Theme Toggle */}
-      <ThemeToggle />
+      <div className="cursor-none">
+        <ThemeToggle />
+      </div>
 
-      {/* Custom Blue Glowy Orb Cursor */}
+      {/* Custom Blue Glowy Orb Cursor - Diffuse Style */}
       <div
         className={`fixed pointer-events-none z-[60] transition-opacity duration-300 ${
           customCursor.visible ? 'opacity-100' : 'opacity-0'
@@ -199,55 +201,57 @@ export default function Index() {
           transform: 'translate(-50%, -50%)',
         }}
       >
-        {/* Main cursor orb */}
+        {/* Diffuse cursor orb with multiple glow layers */}
         <div className="relative">
-          {/* Outer glow rings */}
-          <div
-            className="absolute rounded-full animate-pulse"
-            style={{
-              width: '32px',
-              height: '32px',
-              background: 'radial-gradient(circle, rgba(73, 146, 255, 0.3) 0%, rgba(73, 146, 255, 0.1) 50%, transparent 100%)',
-              transform: 'translate(-50%, -50%)',
-              animation: 'gentle-pulse 2s ease-in-out infinite',
-            }}
-          />
-          <div
-            className="absolute rounded-full animate-pulse"
-            style={{
-              width: '20px',
-              height: '20px',
-              background: 'radial-gradient(circle, rgba(73, 146, 255, 0.5) 0%, rgba(73, 146, 255, 0.2) 50%, transparent 100%)',
-              transform: 'translate(-50%, -50%)',
-              animation: 'gentle-pulse 2s ease-in-out infinite 0.3s',
-            }}
-          />
-          {/* Core orb */}
+          {/* Outermost diffuse glow */}
           <div
             className="absolute rounded-full"
             style={{
-              width: '12px',
-              height: '12px',
-              background: 'radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.9) 0%, rgba(73, 146, 255, 0.9) 30%, rgba(57, 135, 227, 1) 100%)',
+              width: '80px',
+              height: '80px',
+              background: 'radial-gradient(circle, rgba(73, 146, 255, 0.15) 0%, rgba(73, 146, 255, 0.08) 30%, rgba(73, 146, 255, 0.03) 60%, transparent 100%)',
               transform: 'translate(-50%, -50%)',
-              boxShadow: `
-                0 0 15px rgba(73, 146, 255, 0.8),
-                0 0 25px rgba(73, 146, 255, 0.6),
-                0 0 35px rgba(73, 146, 255, 0.4),
-                inset 0 1px 2px rgba(255, 255, 255, 0.3)
-              `,
+              filter: 'blur(4px)',
+              animation: 'gentle-pulse 3s ease-in-out infinite',
+            }}
+          />
+          {/* Secondary glow layer */}
+          <div
+            className="absolute rounded-full"
+            style={{
+              width: '50px',
+              height: '50px',
+              background: 'radial-gradient(circle, rgba(73, 146, 255, 0.25) 0%, rgba(73, 146, 255, 0.15) 40%, rgba(73, 146, 255, 0.05) 70%, transparent 100%)',
+              transform: 'translate(-50%, -50%)',
+              filter: 'blur(2px)',
+              animation: 'gentle-pulse 3s ease-in-out infinite 0.5s',
+            }}
+          />
+          {/* Main glow */}
+          <div
+            className="absolute rounded-full"
+            style={{
+              width: '30px',
+              height: '30px',
+              background: 'radial-gradient(circle, rgba(73, 146, 255, 0.4) 0%, rgba(73, 146, 255, 0.25) 50%, rgba(73, 146, 255, 0.1) 80%, transparent 100%)',
+              transform: 'translate(-50%, -50%)',
+              filter: 'blur(1px)',
               animation: 'orb-pulse 3s ease-in-out infinite',
             }}
           />
-          {/* Inner highlight */}
+          {/* Core bright center */}
           <div
             className="absolute rounded-full"
             style={{
-              width: '4px',
-              height: '4px',
-              background: 'rgba(255, 255, 255, 0.9)',
-              transform: 'translate(-30%, -30%)',
-              filter: 'blur(0.5px)',
+              width: '8px',
+              height: '8px',
+              background: 'radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.9) 0%, rgba(73, 146, 255, 0.8) 40%, rgba(57, 135, 227, 0.9) 100%)',
+              transform: 'translate(-50%, -50%)',
+              boxShadow: `
+                0 0 20px rgba(73, 146, 255, 0.6),
+                0 0 40px rgba(73, 146, 255, 0.4),
+                0 0 60px rgba(73, 146, 255, 0.2)
+              `,
             }}
           />
         </div>
@@ -1657,7 +1661,7 @@ function OrbFloatingButton({
         }}
       />
       <button
-        className={`group relative ${currentSize.padding} ${currentSize.radius} border-2 backdrop-blur-2xl hover:backdrop-blur-3xl transition-all duration-700 hover:shadow-2xl active:scale-95 overflow-hidden ${
+        className={`group relative cursor-none ${currentSize.padding} ${currentSize.radius} border-2 backdrop-blur-2xl hover:backdrop-blur-3xl transition-all duration-700 hover:shadow-2xl active:scale-95 overflow-hidden ${
           theme === "light"
             ? "border-blue-400/40 bg-white/30 hover:border-blue-500/60"
             : "border-blue-300/30 bg-blue-400/5 hover:border-white/40"

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -13,7 +13,11 @@ export default function Index() {
   });
   const badgeRef = useRef<HTMLDivElement>(null);
   const [isLoaded, setIsLoaded] = useState(false);
-  const [customCursor, setCustomCursor] = useState({ x: 0, y: 0, visible: false });
+  const [customCursor, setCustomCursor] = useState({
+    x: 0,
+    y: 0,
+    visible: false,
+  });
   const cursorRef = useRef<HTMLDivElement>(null);
 
   // Framer Motion animation variants
@@ -114,16 +118,16 @@ export default function Index() {
       }
 
       if (!customCursor.visible) {
-        setCustomCursor(prev => ({ ...prev, visible: true }));
+        setCustomCursor((prev) => ({ ...prev, visible: true }));
       }
     };
 
     const handleMouseEnter = () => {
-      setCustomCursor(prev => ({ ...prev, visible: true }));
+      setCustomCursor((prev) => ({ ...prev, visible: true }));
     };
 
     const handleMouseLeave = () => {
-      setCustomCursor(prev => ({ ...prev, visible: false }));
+      setCustomCursor((prev) => ({ ...prev, visible: false }));
     };
 
     window.addEventListener("mousemove", handleMouseMove);
@@ -197,23 +201,24 @@ export default function Index() {
       <div
         ref={cursorRef}
         className={`fixed pointer-events-none z-[60] transition-opacity duration-300 ${
-          customCursor.visible ? 'opacity-100' : 'opacity-0'
+          customCursor.visible ? "opacity-100" : "opacity-0"
         }`}
         style={{
           left: 0,
           top: 0,
-          transform: 'translate3d(0px, 0px, 0)',
-          willChange: 'transform',
+          transform: "translate3d(0px, 0px, 0)",
+          willChange: "transform",
         }}
       >
         {/* Figma-matched cursor orb */}
         <div
           className="absolute rounded-full"
           style={{
-            width: '18px',
-            height: '19px',
-            borderRadius: '19px',
-            background: 'linear-gradient(90deg, #3FBAFF 0.45%, #4992FF 60.5%, #3987E3 122.16%)',
+            width: "18px",
+            height: "19px",
+            borderRadius: "19px",
+            background:
+              "linear-gradient(90deg, #3FBAFF 0.45%, #4992FF 60.5%, #3987E3 122.16%)",
             boxShadow: `
               0 0 31px 0 #4992FF,
               0 0 18px 0 #4992FF,
@@ -221,8 +226,8 @@ export default function Index() {
               0 0 5px 0 #4992FF,
               0 0 1.5px 0 #4992FF
             `,
-            filter: 'blur(1.1px)',
-            transform: 'translate(-50%, -50%)',
+            filter: "blur(1.1px)",
+            transform: "translate(-50%, -50%)",
           }}
         />
       </div>


### PR DESCRIPTION
## Purpose

The user wanted to remove the existing cursor trail effect and replace it with a custom blue glowy orb cursor that matches the Figma design. The goal was to create a smoother, less laggy cursor experience that maintains consistency across all interactive elements without reverting to the default cursor on hover.

## Code changes

- **Removed cursor trail system**: Eliminated the `cursorTrails` state and related trail rendering logic that was causing performance issues
- **Added custom blue orb cursor**: Implemented a new cursor using CSS gradients and box-shadow effects to match the Figma design specifications (18x19px with blue gradient and multiple shadow layers)
- **Optimized cursor performance**: Used direct DOM manipulation with `transform3d` and `willChange` for smoother cursor movement
- **Applied cursor-none globally**: Added `cursor-none` class to the main container and all interactive elements to prevent default cursor from appearing
- **Enhanced cursor visibility**: Added proper show/hide logic with mouse enter/leave events and opacity transitions

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/e37197c9884a4f6f9eaf052a484670f2/neon-zone)

👀 [Preview Link](https://e37197c9884a4f6f9eaf052a484670f2-neon-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>e37197c9884a4f6f9eaf052a484670f2</projectId>-->
<!--<branchName>neon-zone</branchName>-->