### PR TITLE
Add pricing button and adjust navigation layout

### DIFF
--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -5558,7 +5558,7 @@ function MobileHamburgerMenu({
       const sectionMap: { [key: string]: number } = {
         "About us": 1,
         "What we do?": 2,
-        "Pricing": 4,
+        Pricing: 4,
         Services: 3,
         Portfolio: 4,
         "Contact us": 5,

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -5886,7 +5886,7 @@ const ORB_BUTTON_CONFIG = {
       accent: "blue", // Color accent - unified to blue
 
       // Custom positioning for What we do button
-      xOffset: 65, // Moved 50px to the right (15 + 50)
+      xOffset: 75, // Moved 10px more to the right (65 + 10)
       yOffset: 0, // Centered positioning
 
       // What we do button uses global positioning for consistency
@@ -5903,7 +5903,7 @@ const ORB_BUTTON_CONFIG = {
       accent: "blue", // Color accent - unified to blue
 
       // Custom positioning for Pricing button
-      xOffset: -65, // Moved 50px further left (from -15 to -65)
+      xOffset: -75, // Moved 10px more to the left (from -65 to -75)
       yOffset: -10, // Moved 10px upwards (from 0 to -10)
 
       // Pricing button uses global positioning for consistency
@@ -12568,7 +12568,7 @@ const ContactUsSection = React.forwardRef<HTMLDivElement, SectionProps>(
         {/* Floating Communication Icons - Contact specific */}
         <div className="absolute inset-0 pointer-events-none overflow-hidden z-5">
           {[
-            { icon: "��️", delay: 0, x: 15, y: 20, size: 24, duration: 8 },
+            { icon: "���️", delay: 0, x: 15, y: 20, size: 24, duration: 8 },
             { icon: "📧", delay: 2, x: 85, y: 15, size: 20, duration: 6 },
             { icon: "��", delay: 4, x: 25, y: 80, size: 22, duration: 7 },
             { icon: "🌐", delay: 1, x: 75, y: 70, size: 26, duration: 9 },

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -979,7 +979,7 @@ export default function Index() {
                       className="text-xs text-amber-400 mb-1"
                       style={{ lineHeight: "1.2", fontFamily: "monospace" }}
                     >
-                      RAM: ����█�����█������██████���██����███████��█ 50%
+                      RAM: ����█�����██���██████���██����███████��█ 50%
                     </div>
                     <div className="text-xs text-green-400 mt-1">
                       NETWORK: {systemStats.networkUp}GB/s ↑ |{" "}
@@ -5886,7 +5886,7 @@ const ORB_BUTTON_CONFIG = {
       accent: "blue", // Color accent - unified to blue
 
       // Custom positioning for What we do button
-      xOffset: 10, // Positioned at 10px to the right
+      xOffset: 20, // Moved 10px more to the right (10 + 10)
       yOffset: 0, // Centered positioning
 
       // What we do button uses global positioning for consistency
@@ -5903,7 +5903,7 @@ const ORB_BUTTON_CONFIG = {
       accent: "blue", // Color accent - unified to blue
 
       // Custom positioning for Pricing button
-      xOffset: -75, // Moved 10px more to the left (from -65 to -75)
+      xOffset: -80, // Moved 5px more to the left (from -75 to -80)
       yOffset: -10, // Moved 10px upwards (from 0 to -10)
 
       // Pricing button uses global positioning for consistency
@@ -12573,7 +12573,7 @@ const ContactUsSection = React.forwardRef<HTMLDivElement, SectionProps>(
             { icon: "��", delay: 4, x: 25, y: 80, size: 22, duration: 7 },
             { icon: "🌐", delay: 1, x: 75, y: 70, size: 26, duration: 9 },
             {
-              icon: "�����������",
+              icon: "�������������",
               delay: 3,
               x: 10,
               y: 60,

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -904,7 +904,7 @@ export default function Index() {
 ��█║ �����█╔����█��╔═══���█╗██���══█���╗
 █████╔╝ ██║   ██║███�������█╔��
 █��╔�����█╗ ██║   ██║██╔══█��╗
-██║  ██╗╚█���█������█╔╝�����║  ██║
+██║  ██╗╚█���█�����█╔╝�����║  ██║
 �����������╝  ╚═╝ �����������════╝ ╚���╝  ��═╝`}
                 </pre>
                 <div className="retro-subtitle">RETRO DEVELOPMENT SYSTEMS</div>
@@ -5903,8 +5903,8 @@ const ORB_BUTTON_CONFIG = {
       accent: "blue", // Color accent - unified to blue
 
       // Custom positioning for Pricing button
-      xOffset: -15, // Slightly offset for visual interest (opposite of What we do)
-      yOffset: 0, // Centered positioning
+      xOffset: -65, // Moved 50px further left (from -15 to -65)
+      yOffset: -10, // Moved 10px upwards (from 0 to -10)
 
       // Pricing button uses global positioning for consistency
       customRadiusMultiplier: null, // Use global multipliers for consistency

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -904,7 +904,7 @@ export default function Index() {
 ��█║ �����█╔����█��╔═══���█╗██���══█���╗
 █████╔╝ ██║   ██║███�������█╔��
 █��╔�����█╗ ██║   ██║██╔══█��╗
-██║  ██╗╚█���█�����█╔╝�����║  ██║
+██║  ██╗╚█���█������█╔╝�����║  ██║
 �����������╝  ╚═╝ �����������════╝ ╚���╝  ��═╝`}
                 </pre>
                 <div className="retro-subtitle">RETRO DEVELOPMENT SYSTEMS</div>
@@ -5557,7 +5557,8 @@ function MobileHamburgerMenu({
       setIsOpen(false);
       const sectionMap: { [key: string]: number } = {
         "About us": 1,
-        "What we do": 2,
+        "What we do?": 2,
+        "Pricing": 4,
         Services: 3,
         Portfolio: 4,
         "Contact us": 5,
@@ -5575,7 +5576,8 @@ function MobileHamburgerMenu({
 
   const menuItems = [
     { text: "About us" },
-    { text: "What we do" },
+    { text: "What we do?" },
+    { text: "Pricing" },
     { text: "Services" },
     { text: "Portfolio" },
     { text: "Contact us" },
@@ -5875,7 +5877,7 @@ const ORB_BUTTON_CONFIG = {
     },
 
     {
-      text: "What we do",
+      text: "What we do?",
       angle: 0, // Position: center-right for balance
       radius: 280, // Consistent distance from center
       position: "center-right",
@@ -5884,10 +5886,27 @@ const ORB_BUTTON_CONFIG = {
       accent: "blue", // Color accent - unified to blue
 
       // Custom positioning for What we do button
-      xOffset: 15, // Slightly offset for visual interest
+      xOffset: 65, // Moved 50px to the right (15 + 50)
       yOffset: 0, // Centered positioning
 
       // What we do button uses global positioning for consistency
+      customRadiusMultiplier: null, // Use global multipliers for consistency
+    },
+
+    {
+      text: "Pricing",
+      angle: 180, // Position: center-left (opposite of "What we do?")
+      radius: 280, // Consistent distance from center
+      position: "center-left",
+      animationDelay: 0.75,
+      size: "medium", // Consistent sizing
+      accent: "blue", // Color accent - unified to blue
+
+      // Custom positioning for Pricing button
+      xOffset: -15, // Slightly offset for visual interest (opposite of What we do)
+      yOffset: 0, // Centered positioning
+
+      // Pricing button uses global positioning for consistency
       customRadiusMultiplier: null, // Use global multipliers for consistency
     },
 
@@ -6003,29 +6022,36 @@ function OrbFloatingButtons({ animationStep }: { animationStep: number }) {
       {
         ...ORB_BUTTON_CONFIG.buttons[1],
         onClick: () => {
-          console.log("What we do clicked");
+          console.log("What we do? clicked");
           scrollToSection(2);
         },
       },
       {
         ...ORB_BUTTON_CONFIG.buttons[2],
         onClick: () => {
+          console.log("Pricing clicked");
+          scrollToSection(4);
+        },
+      },
+      {
+        ...ORB_BUTTON_CONFIG.buttons[3],
+        onClick: () => {
           console.log("Services clicked");
           scrollToSection(3);
         },
       },
       {
-        ...ORB_BUTTON_CONFIG.buttons[3],
+        ...ORB_BUTTON_CONFIG.buttons[4],
         onClick: () => {
           console.log("Portfolio clicked");
           scrollToSection(4);
         },
       },
       {
-        ...ORB_BUTTON_CONFIG.buttons[4],
+        ...ORB_BUTTON_CONFIG.buttons[5],
         onClick: () => {
           console.log("Contact us clicked");
-          scrollToSection(5);
+          scrollToSection(6);
         },
       },
     ],
@@ -6049,10 +6075,11 @@ function OrbFloatingButtons({ animationStep }: { animationStep: number }) {
           animationStep={animationStep}
           onClick={() => {
             if (button.text === "About us") scrollToSection(1);
-            else if (button.text === "What we do") scrollToSection(2);
+            else if (button.text === "What we do?") scrollToSection(2);
+            else if (button.text === "Pricing") scrollToSection(4);
             else if (button.text === "Services") scrollToSection(3);
-            else if (button.text === "Portfolio") scrollToSection(4);
-            else if (button.text === "Contact us") scrollToSection(5);
+            else if (button.text === "Portfolio") scrollToSection(5);
+            else if (button.text === "Contact us") scrollToSection(6);
             else button.onClick?.();
           }}
         />

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -5886,7 +5886,7 @@ const ORB_BUTTON_CONFIG = {
       accent: "blue", // Color accent - unified to blue
 
       // Custom positioning for What we do button
-      xOffset: 75, // Moved 10px more to the right (65 + 10)
+      xOffset: 10, // Positioned at 10px to the right
       yOffset: 0, // Centered positioning
 
       // What we do button uses global positioning for consistency

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -979,7 +979,7 @@ export default function Index() {
                       className="text-xs text-amber-400 mb-1"
                       style={{ lineHeight: "1.2", fontFamily: "monospace" }}
                     >
-                      RAM: ����█�����██���██████���██����███████��█ 50%
+                      RAM: ����█�����█������██████���██����███████��█ 50%
                     </div>
                     <div className="text-xs text-green-400 mt-1">
                       NETWORK: {systemStats.networkUp}GB/s ↑ |{" "}
@@ -6221,13 +6221,13 @@ function OrbFloatingButton({
       <style
         dangerouslySetInnerHTML={{
           __html: `
-          @media (min-width: 640px) {
+          @media (min-width: 640px) and (max-width: 767px) {
             [style*="--mobile-x"] {
               margin-left: var(--tablet-x) !important;
               margin-top: var(--tablet-y) !important;
             }
           }
-          @media (min-width: 1024px) {
+          @media (min-width: 768px) {
             [style*="--mobile-x"] {
               margin-left: var(--desktop-x) !important;
               margin-top: var(--desktop-y) !important;

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -5886,7 +5886,7 @@ const ORB_BUTTON_CONFIG = {
       accent: "blue", // Color accent - unified to blue
 
       // Custom positioning for What we do button
-      xOffset: 20, // Moved 10px more to the right (10 + 10)
+      xOffset: 70, // Moved 50px more to the right (20 + 50)
       yOffset: 0, // Centered positioning
 
       // What we do button uses global positioning for consistency
@@ -12573,7 +12573,7 @@ const ContactUsSection = React.forwardRef<HTMLDivElement, SectionProps>(
             { icon: "��", delay: 4, x: 25, y: 80, size: 22, duration: 7 },
             { icon: "🌐", delay: 1, x: 75, y: 70, size: 26, duration: 9 },
             {
-              icon: "�������������",
+              icon: "�����������",
               delay: 3,
               x: 10,
               y: 60,


### PR DESCRIPTION
## Purpose

The user requested to add a new pricing button to the navigation and reposition existing navigation elements. The goal was to:
- Add a pricing button positioned opposite to the "What we do" button
- Update the "What we do" button text to include a question mark
- Fine-tune positioning of both buttons through multiple iterations
- Ensure consistent layout across all desktop breakpoints

## Code changes

- **Added new pricing button**: Created a new navigation button with center-left positioning (opposite of "What we do?")
- **Updated button text**: Changed "What we do" to "What we do?" across all navigation components
- **Adjusted positioning**: 
  - Moved "What we do?" button 70px to the right (final position after multiple adjustments)
  - Positioned pricing button 80px to the left and 10px upwards
- **Updated navigation mapping**: Added pricing button to mobile hamburger menu and section scrolling logic
- **Fixed responsive breakpoints**: Updated media queries to ensure consistent layout across desktop breakpoints (640px-767px for tablet, 768px+ for desktop)
- **Updated section navigation**: Adjusted scroll targets to accommodate new button in the navigation flow

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 73`

🔗 [Edit in Builder.io](https://builder.io/app/projects/2f56611bd3bd492db5090d3c84d5d302/mystic-home)

👀 [Preview Link](https://2f56611bd3bd492db5090d3c84d5d302-mystic-home.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>2f56611bd3bd492db5090d3c84d5d302</projectId>-->
<!--<branchName>mystic-home</branchName>-->